### PR TITLE
Separate dataset into two

### DIFF
--- a/data/_targets.R
+++ b/data/_targets.R
@@ -5,6 +5,7 @@ tar_option_set(packages =
     "dplyr"
   , "readr"
   , "stringr"
+  , "tibble"
   , "janitor"
   )
 )
@@ -28,17 +29,51 @@ list(
 
 , tar_target(
     english_col_names,
-    readRDS("english_col_names.rds")
+    c(
+      "household_number" = "NUMH",
+      "survey_year" = "AENC",
+      "reference_quarter" = "TENC",
+      "province" = "TERH",
+      "capital" = "MUNI",
+      "sex" = "SEXO",
+      "place_birth" = "LNAC",
+      "age" = "EDAD",
+      "nationality" = "NACI",
+      "education_level" = "LEST",
+      "formal_educ_system" = "ENRE",
+      "professional_training" = "FOCU",
+      "retirement_status" = "SJUB",
+      "household_duties" = "SILH",
+      "part-time_empl" = "EMPTP",
+      "reason_reduced_work" = "JRED",
+      "search_work" = "BUSQ",
+      "search_reason" = "RBUSQ",
+      "search_steps" = "GBUSQ",
+      "search_method" = "FBUSQ",
+      "search_months" = "MSBUSQ1",
+      "availability" = "DISP",
+      "relation_to_activity1" = "PRA1",
+      "relation_to_activity2" = "PRA2",
+      "main_occupation" = "PROF",
+      "main_activity" = "RACT",
+      "main_prof_situation" = "SPRO",
+      "main_sector" = "SECT",
+      "contract_type" = "CONTR",
+      "hours" = "HTRA",
+      "relationship" = "PARE",
+      "elevator" = "ELEV"
+    )
   )
 
-, tar_target(
+ , tar_target(
     pra_2023,
-    setNames(raw_pra_2023, english_col_names) |>
-    clean_names() |>
+    rename(raw_pra_2023, all_of(english_col_names)) |>
     filter(reference_quarter == 1) |>
-    select(-level_of_studies_completed) |> # This variable is completely empty
-    mutate(elevator = str_replace_all(elevator, ",", "."))
-  )
+    select(-education_level) |> # This variable is completely empty
+    mutate(elevator = str_replace_all(elevator, ",", ".")) |>
+    rowid_to_column() |>
+    mutate(matricule = paste0(rowid, "_", household_number))
+   )
 
 , tar_target(
     pra_2023_csv,
@@ -46,5 +81,49 @@ list(
               "pra_2023.csv",
               row.names = FALSE)
   )
-)
 
+, tar_target(
+    shared_columns,
+    c(
+      "age",
+      "matricule",
+      "nationality",
+      "place_birth",
+      "sex",
+      "province"
+    )
+  )
+
+, tar_target(
+    pra_A,
+    select(
+      pra_2023,
+      all_of(shared_columns),
+      household_duties,
+      relation_to_activity1,
+      relation_to_activity2,
+    )
+  )
+
+
+, tar_target(
+    pra_B,
+    select(
+      pra_2023,
+      all_of(shared_columns),
+      relationship,
+      main_occupation,
+      availability,
+      search_work,
+      search_reason,
+      search_steps,
+      search_method,
+      search_months,
+      main_activity,
+      main_prof_situation,
+      main_sector,
+      contract_type,
+      hours
+    )
+  )
+)

--- a/data/default.nix
+++ b/data/default.nix
@@ -12,6 +12,7 @@ let
    
   system_packages = builtins.attrValues {
     inherit (pkgs) 
+      emacs29
       glibcLocales
       nix
       R;


### PR DESCRIPTION
ping @alex-l637 @BasheerL

The idea here is to separate the dataset into two other datasets.
One dataset should only contain info on the person, and the second on the person’s labour supply situation. 

In the `data/_targets.R` script, check out `shared_columns` which lists the shared columns between the two datasets (line 86). Then, in the same script, check out `pra_A` and `pra_B` (lines 97 and 109 respectively). These are the two datasets. Check out the documentation (the excel file inside of `data/` to check out the list of available columns. Let me know what you think of this split.